### PR TITLE
Fix runtime error induced by #18

### DIFF
--- a/data_reader.py
+++ b/data_reader.py
@@ -181,7 +181,7 @@ class DataReader(object):
       filename_queue = tf.train.string_input_producer(file_names, seed=seed)
       reader = tf.TFRecordReader()
 
-      read_ops = [self._make_read_op(reader, filename_queue)
+      read_ops = [self._make_read_op(reader, filename_queue, seed)
                   for _ in range(num_threads)]
 
       dtypes = nest.map_structure(lambda x: x.dtype, read_ops[0])
@@ -208,7 +208,7 @@ class DataReader(object):
     query = Query(context=context, query_camera=query_camera)
     return TaskData(query=query, target=target)
 
-  def _make_read_op(self, reader, filename_queue):
+  def _make_read_op(self, reader, filename_queue, seed):
     """Instantiates the ops used to read and parse the data into tensors."""
     _, raw_data = reader.read_up_to(filename_queue, num_records=16)
     feature_map = {


### PR DESCRIPTION
https://github.com/deepmind/gqn-datasets/pull/18 creates a runtime `NameError` (pops up when you run the demo code). This is a small patch to fix it.

```sh
Traceback (most recent call last):
  File "demo_code.py", line 5, in <module>
    data_reader = DataReader(dataset='rooms_free_camera_no_object_rotations', context_size=5, root=root_path)
  File "data_reader.py", line 182, in __init__
    for _ in range(num_threads)]
  File "data_reader.py", line 182, in <listcomp>
    for _ in range(num_threads)]
  File "data_reader.py", line 219, in _make_read_op
    indices = self._get_randomized_indices(seed)
NameError: name 'seed' is not defined
```